### PR TITLE
Don't login on heroku unless necessary

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,19 +8,13 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Login to docker
-          command: |
-            docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
-            docker login --username=$DOCKER_USER --password=$DOCKER_PASS
-      - run:
           name: Pulling docker image
           command: |
             docker pull decidim/decidim-monitor || true
-            docker pull registry.heroku.com/decidim-monitor/web || true
       - run:
           name: Build image
           command: |
-            docker build -t registry.heroku.com/decidim-monitor/web -t decidim/decidim-monitor:latest --cache-from registry.heroku.com/decidim-monitor/web .
+            docker build -t registry.heroku.com/decidim-monitor/web -t decidim/decidim-monitor:latest --cache-from decidim/decidim-monitor .
       - run:
           name: Run tests
           command: |
@@ -30,11 +24,13 @@ jobs:
           name: Push deployment image
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login --username=_ --password=$HEROKU_AUTH_TOKEN registry.heroku.com
               docker push registry.heroku.com/decidim-monitor/web
             fi
       - run:
           name: Push docker hub image
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              docker login --username=$DOCKER_USER --password=$DOCKER_PASS
               docker push decidim/decidim-monitor:latest
             fi


### PR DESCRIPTION
This fixes external builds by not logging in on heroku unless necessary.